### PR TITLE
DB2 support and ordering by IDs

### DIFF
--- a/src/clj_record/core.clj
+++ b/src/clj_record/core.clj
@@ -81,7 +81,7 @@ instance."
           (if (map? attributes-or-where-params)
             (to-conditions attributes-or-where-params)
             attributes-or-where-params)
-          select-query (format "select * from %s where %s" (table-name model-name) parameterized-where)]
+          select-query (format "select * from %s where %s order by id" (table-name model-name) parameterized-where)]
     (find-by-sql model-name (apply vector select-query values))))
 
 (defn find-record

--- a/src/clj_record/util.clj
+++ b/src/clj_record/util.clj
@@ -28,6 +28,8 @@
   "SELECT LAST_INSERT_ID()")
 (defmethod id-query-for "h2" [_ _]
   "CALL IDENTITY()")
+(defmethod id-query-for "db2" [_ _]
+  "VALUES IDENTITY_VAL_LOCAL()")
 (defmethod id-query-for :default [db-spec _]
   (throw (Exception. (str "Unrecognized db-spec subprotocol: " db-spec))))
 

--- a/test/clj_record/test_helper.clj
+++ b/test/clj_record/test_helper.clj
@@ -29,10 +29,12 @@
 (defmulti get-id-key-spec :subprotocol)
 (defmethod get-id-key-spec "derby" [db-spec name]
   [:id :int (str "GENERATED ALWAYS AS IDENTITY CONSTRAINT " name " PRIMARY KEY")])
+(defmethod get-id-key-spec "db2" [db-spec name]
+  [:id :int (str "GENERATED ALWAYS AS IDENTITY CONSTRAINT " name " PRIMARY KEY")])
 (defmethod get-id-key-spec :default [db-spec name]
   [:id "SERIAL UNIQUE PRIMARY KEY"])
 
-(def table-specs 
+(def table-specs
   { :manufacturers
       [ (get-id-key-spec db "manufacturer_pk")
         [:name    "VARCHAR(32)" "NOT NULL"]

--- a/test/clj_record/test_model/config.clj
+++ b/test/clj_record/test_model/config.clj
@@ -14,8 +14,15 @@
            :password "pass"}))
 
 (comment
-  (def db {:classname "com.mysql.jdbc.Driver" 
-	   :subprotocol "mysql" 
+  (def db {:classname "com.mysql.jdbc.Driver"
+	   :subprotocol "mysql"
 	   :user "root" 
 	   :password "root" 
 	   :subname "//localhost/test"}))
+
+(comment
+  (def db {:classname "com.ibm.db2.jcc.DB2Driver"
+	   :subprotocol "db2"
+	   :user "db2"
+	   :password "db2"
+	   :subname "//localhost:50000/clojure:currentSchema=CLJRECORD;"}))


### PR DESCRIPTION
As discussed on the dev group, this change adds DB2 support and a hardcoded ordering by ID in the find-records function.

Yair
