### PR TITLE
Updated dependencies and choosing innodb for resetting db with mysql

### DIFF
--- a/db_contents.clj
+++ b/db_contents.clj
@@ -1,15 +1,15 @@
-(require 'clj-record.config)
+(require 'clj-record.test-model.config)
 (require 'clojure.contrib.sql)
 
 
 (println "manufacturers")
-(clojure.contrib.sql/with-connection clj-record.config/db
+(clojure.contrib.sql/with-connection clj-record.test-model.config/db
   (clojure.contrib.sql/with-query-results rows ["select * from manufacturers"]
     (doseq [row rows] (println row))))
 
 (println)
 
 (println "products")
-(clojure.contrib.sql/with-connection clj-record.config/db
-  (clojure.contrib.sql/with-query-results rows ["select * from products"]
+(clojure.contrib.sql/with-connection clj-record.test-model.config/db
+  (clojure.contrib.sql/with-query-results rows ["select * from productos"]
     (doseq [row rows] (println row))))


### PR DESCRIPTION
- Have merged https://github.com/duck1123/clj-record.git (Updated dependencies to 1.3)
- Resetting db with mysql now takes innodb as engine even if it doesnt have innodb as default engine
