### PR TITLE
Add type hints to eliminate reflection.

### DIFF
--- a/src/clj_record/util.clj
+++ b/src/clj_record/util.clj
@@ -2,7 +2,7 @@
   "Assorted utilities for internal use."
   (:require [clojure.string :as string]))
 
-(defn singularize [plural]
+(defn singularize [^String plural]
   (let [lc (.toLowerCase plural)]
     (condp re-find lc
       #"ies$" (string/replace lc #"ies$" "y")
@@ -10,14 +10,14 @@
       #"s$" (string/replace lc #"s$" "")
       lc)))
 
-(defn pluralize [word]
+(defn pluralize [^String word]
   (let [lc (.toLowerCase word)]
     (cond
       (.endsWith lc "y") (string/replace lc #"y$" "ies")
       (some #(.endsWith lc %) ["s" "z" "ch" "sh" "x"]) (str lc "es")
       :else (str lc "s"))))
 
-(defn dashes-to-underscores [s]
+(defn dashes-to-underscores [^String s]
   (.replaceAll s "-" "_"))
 
 (defmulti  id-query-for :subprotocol)


### PR DESCRIPTION
Running 'lein check' was producing these warnings:
clj_record/util.clj:6 - reference to field toLowerCase can't be resolved.
clj_record/util.clj:14 - reference to field toLowerCase can't be resolved.
clj_record/util.clj:16 - call to endsWith can't be resolved.
clj_record/util.clj:17 - call to endsWith can't be resolved.
clj_record/util.clj:21 - call to replaceAll can't be resolved.
clj_record/util.clj:6 - reference to field toLowerCase can't be resolved.
clj_record/util.clj:14 - reference to field toLowerCase can't be resolved.
clj_record/util.clj:16 - call to endsWith can't be resolved.
clj_record/util.clj:17 - call to endsWith can't be resolved.
clj_record/util.clj:21 - call to replaceAll can't be resolved.
