### PR TITLE
Add a function for getting all records

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -46,6 +46,7 @@ into function definitions for basic crud operations:
 
 * get-record (by id)
 * find-record (by a map of attributes)
+* all-records
 * find-records (by a map of attributes)
 * find-by-sql (by a SQL string and "?" parameter values)
 * insert (from a map of attributes, returning the generated id)

--- a/src/clj_record/core.clj
+++ b/src/clj_record/core.clj
@@ -75,6 +75,12 @@ instance."
       (sql/with-query-results rows select-query-and-values
         (doall (after-load model-name rows)))))
 
+(defn all-records
+  "Returns a vector of all records."
+  [model-name]
+  (let [select-query (format "select * from %s" (table-name model-name))]
+    (find-by-sql model-name [select-query])))
+
 (defn find-records
   "Returns a vector of matching records.
   Given a where-params vector, uses it as-is. (See clojure.java.jdbc/with-query-results.)
@@ -217,6 +223,8 @@ instance."
         ([attributes#] (record-count ~model-name attributes#)))
       (defn ~'get-record [id#]
         (get-record ~model-name id#))
+      (defn ~'all-records []
+        (all-records ~model-name))
       (defn ~'find-records [attributes#]
         (find-records ~model-name attributes#))
       (defn ~'find-record [attributes#]

--- a/test/clj_record/core_test.clj
+++ b/test/clj_record/core_test.clj
@@ -27,6 +27,11 @@
 (defdbtest get-record-throws-if-not-found
   (is (thrown? IllegalArgumentException (manufacturer/get-record -1))))
 
+(defdbtest all-records-returns-all
+  (let [humedai (manufacturer/create (valid-manufacturer-with {:name "Humedai Motors"}))
+        other-1 (manufacturer/create (valid-manufacturer-with {:name "Some Other"}))]
+    (is (= #{humedai other-1} (apply hash-set (manufacturer/all-records))))))
+
 (defdbtest find-records-can-do-lookup-by-attribute-equality-conditions
   (let [humedai (manufacturer/create (valid-manufacturer-with {:name "Humedai Motors"}))
         other-1 (manufacturer/create (valid-manufacturer-with {:name "Some Other"}))]


### PR DESCRIPTION
I needed a function for getting all records of a type (similar to `Model.all` in ActiveRecord), so added `all-records`. It takes no arguments and simply issues a SELECT without a WHERE clause
